### PR TITLE
fix processing instructions in canonicalized sources

### DIFF
--- a/4.0.1/mei-source_canonicalized_v4.0.1.xml
+++ b/4.0.1/mei-source_canonicalized_v4.0.1.xml
@@ -16,8 +16,8 @@
 
   CONTACT: info@music-encoding.org
 -->
-<?xml-model href=../../../source/"validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href=../../../source/"validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron?>
+<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0?>
 <!--canonicalized: 2023-07-10T20:52:45.2233013+02:00-->
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" version="5.0" rend="book" xml:lang="en">
   <teiHeader>

--- a/4.0.1/mei-source_canonicalized_v4.0.1.xml
+++ b/4.0.1/mei-source_canonicalized_v4.0.1.xml
@@ -16,8 +16,8 @@
 
   CONTACT: info@music-encoding.org
 -->
-<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron?>
-<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <!--canonicalized: 2023-07-10T20:52:45.2233013+02:00-->
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" version="5.0" rend="book" xml:lang="en">
   <teiHeader>

--- a/5.0/mei-source_canonicalized_v5.0.xml
+++ b/5.0/mei-source_canonicalized_v5.0.xml
@@ -17,9 +17,9 @@
   
   CONTACT: info@music-encoding.org
 -->
-<?xml-model href=../../../source/"validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href=../../../source/"validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href=../../../source/"validation/mei-source.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron?>
+<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0?>
+<?xml-model href="../../../source/validation/mei-source.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron?>
 <!--canonicalized: 2023-09-05T20:03:32.414441906+02:00-->
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" version="5.0" rend="book" xml:lang="en">
    <teiHeader>

--- a/5.0/mei-source_canonicalized_v5.0.xml
+++ b/5.0/mei-source_canonicalized_v5.0.xml
@@ -17,9 +17,9 @@
   
   CONTACT: info@music-encoding.org
 -->
-<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron?>
-<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0?>
-<?xml-model href="../../../source/validation/mei-source.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../source/validation/mei-source.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron?>
 <!--canonicalized: 2023-09-05T20:03:32.414441906+02:00-->
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" version="5.0" rend="book" xml:lang="en">
    <teiHeader>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MEI Schema
 
-The [repository](https://github.com/music-encoding/schema/) where the MEI schema are published.
+The [repository](https://github.com/music-encoding/schema/) where the MEI Schemas are published.
 
 The content of this repository should not be edited directly. Contributions to the MEI Schema should be made directly to the [music-encoding](https://github.com/music-encoding/music-encoding) source repository.
 

--- a/dev/mei-source_canonicalized_v5.1-dev.xml
+++ b/dev/mei-source_canonicalized_v5.1-dev.xml
@@ -17,9 +17,9 @@
   
   CONTACT: info@music-encoding.org
 -->
-<?xml-model href=../../../source/"validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href=../../../source/"validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href=../../../source/"validation/mei-source.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron?>
+<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0?>
+<?xml-model href="../../../source/validation/mei-source.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron?>
 <!--canonicalized: 2024-07-18T16:40:20.887200155+02:00-->
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" version="5.0" rend="book" xml:lang="en">
    <teiHeader>

--- a/dev/mei-source_canonicalized_v5.1-dev.xml
+++ b/dev/mei-source_canonicalized_v5.1-dev.xml
@@ -17,9 +17,9 @@
   
   CONTACT: info@music-encoding.org
 -->
-<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron?>
-<?xml-model href="../../../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0?>
-<?xml-model href="../../../source/validation/mei-source.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron?>
+<?xml-model href=../../../source/"validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href=../../../source/"validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href=../../../source/"validation/mei-source.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <!--canonicalized: 2024-07-18T16:40:20.887200155+02:00-->
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" version="5.0" rend="book" xml:lang="en">
    <teiHeader>


### PR DESCRIPTION
This PR fixes a small bug in the canonicalized source files where the href attributes were formatted wrongly. 

Also it fixes a small typo in the readme.